### PR TITLE
Implemented SI pipeline

### DIFF
--- a/notebooks/spikeinterface_pipeline.ipynb
+++ b/notebooks/spikeinterface_pipeline.ipynb
@@ -1,0 +1,772 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SpikeInterface pipeline for Tank Lab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import spikeextractors as se\n",
+    "import spiketoolkit as st\n",
+    "import spikesorters as ss\n",
+    "import spikecomparison as sc\n",
+    "import spikewidgets as sw\n",
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from pprint import pprint\n",
+    "%matplotlib notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1) Load AP recordings, LF recordings and TTL signals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ap_bin_path = '/Users/abuccino/Documents/Data/catalyst/brody/A256_bank1_2020_09_30_g0/A256_bank1_2020_09_30_g0_t0.imec0.ap.bin'\n",
+    "lf_bin_path = '/Users/abuccino/Documents/Data/catalyst/brody/A256_bank1_2020_09_30_g0/A256_bank1_2020_09_30_g0_t0.imec0.lf.bin'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recording_folder = Path(ap_bin_path).parent"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Make spikeinterface folders"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spikeinterface_folder = recording_folder / 'spikeinterface'\n",
+    "spikeinterface_folder.mkdir(parents=True, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recording_ap = se.SpikeGLXRecordingExtractor(ap_bin_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recording_lf = se.SpikeGLXRecordingExtractor(lf_bin_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Sampling frequency AP: {recording_ap.get_sampling_frequency()}\")\n",
+    "print(f\"Sampling frequency LF: {recording_lf.get_sampling_frequency()}\")      "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load TTL signals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ttl, states = recording_ap.get_ttl_events()\n",
+    "rising_times = ttl[states==1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_time = recording_ap.frame_to_time(rising_times[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_frame_ap = int(recording_ap.time_to_frame(start_time))\n",
+    "start_frame_lf = int(recording_lf.time_to_frame(start_time))\n",
+    "print(f\"Start frame AP: {start_frame_ap}\")\n",
+    "print(f\"Start frame LF: {start_frame_lf}\")    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Synchronize recording"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recording_ap_sync = se.SubRecordingExtractor(recording_ap, start_frame=start_frame_ap)\n",
+    "recording_lf_sync = se.SubRecordingExtractor(recording_lf, start_frame=start_frame_lf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Inspect signals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w_ts_ap = sw.plot_timeseries(recording_ap, channel_ids=recording_ap.get_channel_ids()[::10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w_ts_lf = sw.plot_timeseries(recording_lf, channel_ids=recording_lf.get_channel_ids()[::10])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2) Pre-processing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "apply_cmr = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if apply_cmr:\n",
+    "    recording_processed = st.preprocessing.common_reference(recording_ap_sync)\n",
+    "else:\n",
+    "    recording_processed = recording_ap_sync"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_frames = recording_processed.get_num_frames()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3) Run spike sorters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sorter_list = ['kilosort2', 'ironclust', 'spykingcircus']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Inspect sorter-specific parameters and defaults\n",
+    "for sorter in sorter_list:\n",
+    "    print(f\"{sorter} params description:\")\n",
+    "    pprint(ss.get_params_description(sorter))\n",
+    "    print(\"Default params:\")\n",
+    "    pprint(ss.get_default_params(sorter))    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# user-specific parameters\n",
+    "sorter_params = dict(kilosort2=dict(car=False),\n",
+    "                     ironclust=dict(),\n",
+    "                     spykingcircus=dict())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sorting_outputs = ss.run_sorters(sorter_list=['kilosort2', 'ironclust', 'spykingcircus'], \n",
+    "                                 recording_dict_or_list=dict(rec0=rec), \n",
+    "                                 sorter_params=sorter_params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ss.run_sorters?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4) Post-processing: extract waveforms, templates, quality metrics, extracellular features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set postprocessing parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Post-processing params\n",
+    "postprocessing_params = st.postprocessing.get_common_params()\n",
+    "pprint(postprocessing_params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (optional) change parameters\n",
+    "postprocessing_params['max_spikes_per_unit'] = 1000  # with None, all waveforms are extracted"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set quality metric list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Quality metrics\n",
+    "qc_list = st.validation.get_quality_metrics_list()\n",
+    "print(f\"Available quality metrics: {qc_list}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (optional) define subset of qc\n",
+    "qc_list = ['snr', 'isi_violation', 'firing_rate']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set extracellular features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extracellular features\n",
+    "ec_list = st.postprocessing.get_template_features_list()\n",
+    "print(f\"Available EC features: {ec_list}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (optional) define subset of ec\n",
+    "ec_list = ['peak_to_valley', 'halfwidth']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Postprocess all sorting outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st.validation.compute_quality_metrics?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for result_name, sorting in sorting_outputs.items():\n",
+    "    rec_name, sorter = result_name\n",
+    "    tmp_folder = spikeinterface_folder / 'tmp' / sorter\n",
+    "    tmp_folder.mkdir(parents=True)\n",
+    "    \n",
+    "    # set local tmp folder\n",
+    "    sorting.set_tmp_folder(tmp_folder)\n",
+    "    \n",
+    "    # compute waveforms\n",
+    "    waveforms = st.postprocessing.get_unit_waveforms(recording_processed, sorting, **postprocessing_params)\n",
+    "    \n",
+    "    # compute templates\n",
+    "    templates = st.postprocessing.get_unit_templates(recording_processed, sorting, **postprocessing_params)\n",
+    "    \n",
+    "    # comput EC features\n",
+    "    ec = st.postprocessing.compute_unit_template_features(recording_processed, sorting,\n",
+    "                                                          feature_names=ec_list, as_dataframe=True)\n",
+    "    # compute QCs\n",
+    "    qc = st.validation.compute_quality_metrics(sorting, recording=recording_processed, \n",
+    "                                               metric_names=qc_list, as_dataframe=True)\n",
+    "    \n",
+    "    # export to phy\n",
+    "    phy_folder = spikeinterface_folder / 'phy' / sorter\n",
+    "    st.postprocessing.export_to_phy(recording_processed, sorting, phy_folder)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5) Ensamble spike sorting\n",
+    "\n",
+    "If len(sorter_list) > 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# retrieve sortings and sorter names\n",
+    "sorting_list = []\n",
+    "sorter_names_comp = []\n",
+    "for result_name, sorting in sorting_outputs.items():\n",
+    "    rec_name, sorter = result_name\n",
+    "    sorting_list.append(sorting)\n",
+    "    sorter_names_comp.append(sorter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# run multisorting comparison\n",
+    "mcmp = sc.compare_multiple_sorters(sorting_list=sorting_list, name_list=sorter_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot agreement results\n",
+    "w_agr = sw.plot_multicomp_agreement(mcmp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# extract ensamble sorting\n",
+    "sorting_ensamble = mcmp.get_agreement_sorting(minimum_agreement_count=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO add number agreement as property"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 6) Automatic curation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define curators and thresholds\n",
+    "isi_violation_threshold = 0.5\n",
+    "snr_threshold = 5\n",
+    "firing_rate_threshold = 0.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sorting_auto_curated = []\n",
+    "sorter_names_curation = []\n",
+    "for result_name, sorting in sorting_outputs.items():\n",
+    "    rec_name, sorter = result_name\n",
+    "    sorter_names_curation.append(sorter)\n",
+    "    \n",
+    "    # firing rate threshold\n",
+    "    sorting_curated = st.curation.threshold_firing_rates(sorting, duration_in_frames=num_frames,\n",
+    "                                                         threshold=firing_rate_threshold, \n",
+    "                                                         threshold_sign='less')\n",
+    "    \n",
+    "    # isi violation threshold\n",
+    "    sorting_curated = st.curation.threshold_isi_violations(sorting, duration_in_frames=num_frames,\n",
+    "                                                           threshold=isi_violation_threshold, \n",
+    "                                                           threshold_sign='greater')\n",
+    "    \n",
+    "    # isi violation threshold\n",
+    "    sorting_curated = st.curation.threshold_snrs(sorting, recording=recording_processed,\n",
+    "                                                 threshold=snr_threshold, \n",
+    "                                                 threshold_sign='less')\n",
+    "    sorting_auto_curated.append(sorting_curated)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7) Save all outputs in spikeinterface folder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cache_raw = False\n",
+    "cache_processed = False\n",
+    "cache_lfp = False\n",
+    "cache_sortings = True\n",
+    "cache_curated = True\n",
+    "cache_comparison = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cache_folder = spikeinterface_folder / 'cache'\n",
+    "cache_folder.mkdir(parents=True, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dump recordings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if cache_raw:\n",
+    "    recording_raw_cache = se.CacheRecordingExtractor(recording_ap_sync, \n",
+    "                                                     save_path=cache_folder / 'raw.dat')\n",
+    "else:\n",
+    "    recording_raw_cache = recording_ap_sync\n",
+    "recording_raw_cache.dump_to_pickle(cache_folder / 'raw.pkl')\n",
+    "\n",
+    "if cache_raw:\n",
+    "    recording_lfp_cache = se.CacheRecordingExtractor(recording_lf_sync, \n",
+    "                                                     save_path=cache_folder / 'lfp.dat')\n",
+    "else:\n",
+    "    recording_lfp_cache = recording_lf_sync\n",
+    "recording_lfp_cache.dump_to_pickle(cache_folder / 'lfp.pkl')\n",
+    "\n",
+    "if cache_processed:\n",
+    "    recording_processed_cache = se.CacheRecordingExtractor(recording_processed, \n",
+    "                                                           save_path=cache_folder / 'processed.dat')\n",
+    "else:\n",
+    "    recording_processed_cache = recording_processed\n",
+    "recording_processed_cache.dump_to_pickle(cache_folder / 'raw.pkl')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dump sortings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sorter output\n",
+    "for result_name, sorting in sorting_outputs.items():\n",
+    "    rec_name, sorter = result_name\n",
+    "    if cache_sortings:\n",
+    "        sorting_cache = se.CacheSortingExtractor(sorting, cache_folder / f'sorting_{sorter}.npz')\n",
+    "    else:\n",
+    "        sorting_cache = sorting\n",
+    "    sorting_cache.dump_to_pickle(cache_folder / f'sorting_{sorter}.pkl', include_features=False)\n",
+    "\n",
+    "# Curated output\n",
+    "for (sorter, sorting_curated) in zip(sorter_names_curation, sorting_auto_curated):\n",
+    "    if cache_curated:\n",
+    "        sorting_auto_cache = se.CacheSortingExtractor(sorting_curated, cache_folder / f'sorting_{sorter}_auto.npz')\n",
+    "    else:\n",
+    "        sorting_auto_cache = sorting_curated\n",
+    "    sorting_auto_cache.dump_to_pickle(cache_folder / f'sorting_{sorter}_auto.pkl', include_features=False)\n",
+    "    \n",
+    "# Ensamble output\n",
+    "if cache_comparison:\n",
+    "    sorting_ensamble_cache = se.CacheSortingExtractor(sorting, cache_folder / f'sorting_ensamble.npz')\n",
+    "else:\n",
+    "    sorting_ensamble_cache = sorting_ensamble\n",
+    "sorting_ensamble_cache.dump_to_pickle(cache_folder / f'sorting_ensamble.pkl', include_features=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export to phy\n",
+    "\n",
+    "note to myself (add the possibility to save specific user defined properties)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st.postprocessing.export_to_phy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Concatenating multiple recordings (we'll need it!)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rec_files = [rec_file, rec_file, rec_file]\n",
+    "recording_list = []\n",
+    "\n",
+    "for f in rec_files:\n",
+    "    rec_i = se.SpikeGLXRecordingExtractor(f)\n",
+    "    recording_list.append(rec_i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_rec = se.MultiRecordingTimeExtractor?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_rec = se.MultiRecordingTimeExtractor(recordings=recording_list, \n",
+    "                                           epoch_names=['baselilne', 'intervention', 'post'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "isinstance(multi_rec, se.RecordingExtractor)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Added first version of SI pipeline:

- 1) Load AP recordings, LF recordings and TTL signals
- 2) Pre-processing
- 3) Run spike sorters 
- 4) Post-processing: extract waveforms, templates, quality metrics, extracellular features
- 5) Ensamble spike sorting
- 6) Automatic curation
- 7) Save all outputs in spikeinterface folder

Still needs proper testing, but we can start discussing about it!
