### PR TITLE
added SpikeGLX conversion

### DIFF
--- a/tank_lab_to_nwb/convert_towers_task/convert_towers.py
+++ b/tank_lab_to_nwb/convert_towers_task/convert_towers.py
@@ -28,10 +28,10 @@ def run_tower_conv(session, nwbfile_path):
         if not os.path.isfile(nwbfile_path):
             # construct input_args dict according to input schema
             input_args = dict(
-                #     GLXRecording=dict(
-                #         file_path="D:/Neuropixels/Neuropixels/A256_bank1_2020_09_30/"
-                #         "A256_bank1_2020_09_30_g0/A256_bank1_2020_09_30_g0_t0.imec0.ap.bin"
-                #     ),
+                SpikeGLXRecording=dict(
+                    file_path="D:/Neuropixels/Neuropixels/A256_bank1_2020_09_30/"
+                    "A256_bank1_2020_09_30_g0/A256_bank1_2020_09_30_g0_t0.imec0.ap.bin"
+                ),
                 TowersPosition=dict(folder_path=session)
             )
 

--- a/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
+++ b/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 from dateutil.parser import parse as dateparse
 from isodate import duration_isoformat
-from nwb_conversion_tools import NWBConverter
+from nwb_conversion_tools import NWBConverter, SpikeGLXRecordingInterface
 
 from .towerspositiondatainterface import TowersPositionInterface
 from ..utils import convert_mat_file_to_dict
@@ -12,7 +12,7 @@ from ..utils import convert_mat_file_to_dict
 
 class TowersNWBConverter(NWBConverter):
     data_interface_classes = dict(
-        #            SpikeGLXRecording=SpikeGLXRecordingInterface,
+        SpikeGLXRecording=SpikeGLXRecordingInterface,
         TowersPosition=TowersPositionInterface,
     )
 
@@ -70,6 +70,7 @@ class TowersNWBConverter(NWBConverter):
             #         }
             #     }
             # },
+            SpikeGLXRecording=None,
             TowersPosition=dict()
         )
 


### PR DESCRIPTION
Warning: this is only compatible pending a quick fix to the BaseRecordingExtractor to handle the metadata routing to SpikeExtractors properly when there is no metadata to pass.