### PR TITLE
Updated VirmenDataInterface

### DIFF
--- a/tank_lab_to_nwb/convert_towers_task/convert_towers.py
+++ b/tank_lab_to_nwb/convert_towers_task/convert_towers.py
@@ -14,10 +14,10 @@ base_path = "D:/Neuropixels/TowersTask"
 # Manual list of selected sessions that cause problems with the general functionality
 exlude_sessions = []
 
-session_strings = ["PoissonBlocksReboot_cohort1_VRTrain6_E75_T_20181105"]
+virmen_strings = ["PoissonBlocksReboot_cohort1_VRTrain6_E75_T_20181105.mat"]
 nwbfile_paths = []
-for j, session in enumerate(session_strings):
-    session_strings[j] = os.path.join(base_path, session_strings[j])
+for j, session in enumerate(virmen_strings):
+    virmen_strings[j] = os.path.join(base_path, virmen_strings[j])
     nwbfile_paths.append(os.path.join(base_path, session) + "_local_stub.nwb")
 
 

--- a/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
+++ b/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
@@ -6,7 +6,7 @@ from dateutil.parser import parse as dateparse
 from isodate import duration_isoformat
 from nwb_conversion_tools import NWBConverter, SpikeGLXRecordingInterface
 
-from .towersbehaviordatainterface import VirmenDataInterface
+from .virmenbehaviordatainterface import VirmenDataInterface
 from ..utils import convert_mat_file_to_dict
 
 

--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -33,7 +33,7 @@ class VirmenDataInterface(BaseDataInterface):
         return dict(
             required=['folder_path'],
             properties=dict(
-                folder_path=dict(type='string')
+                file_path=dict(type='string')
             )
         )
 
@@ -71,8 +71,7 @@ class VirmenDataInterface(BaseDataInterface):
             DESCRIPTION. The default is False.
 
         """
-        session_path = self.input_args['folder_path']
-        mat_file = session_path + ".mat"
+        mat_file = self.input_args['file_path']
         matin = convert_mat_file_to_dict(mat_file)
         # TODO: move this to get_metadata in main converter
         session_start_time = array_to_dt(matin['log']['session']['start'])


### PR DESCRIPTION
A couple of fixes in the Virmen interface

1. the `folder_path` was actually expecting the folder + the stem of the file. I think it's clearer to have a `file_path` instead pointing to the mat file

2. Renamed `towersbehaviordatainterface.py` -> `virmenbehaviordatainterface.py`

3. Applied changes to the `convert_towers.py` accordingly