### PR TITLE
Simplify test script, and debugging

### DIFF
--- a/tank_lab_to_nwb/convert_towers_task/convert_towers.py
+++ b/tank_lab_to_nwb/convert_towers_task/convert_towers.py
@@ -13,7 +13,8 @@ if base_path.is_dir():
     if not nwbfile_path.is_file():
         input_args = dict(
             SpikeGLXRecording=dict(
-                file_path=spikeglx_file_path
+                file_path=spikeglx_file_path,
+                dtype="int16"
             ),
             VirmenData=dict(
                 file_path=virmen_file_path
@@ -22,12 +23,8 @@ if base_path.is_dir():
 
         converter = TowersNWBConverter(**input_args)
         metadata = converter.get_metadata()
-
-        # Session specific metadata
-
         converter.run_conversion(
             nwbfile_path=str(nwbfile_path.absolute()),
             metadata_dict=metadata,
-            stub_test=True,
-            sync_with_ttl=True
+            stub_test=True
         )

--- a/tank_lab_to_nwb/convert_towers_task/convert_towers.py
+++ b/tank_lab_to_nwb/convert_towers_task/convert_towers.py
@@ -14,7 +14,6 @@ if base_path.is_dir():
         input_args = dict(
             SpikeGLXRecording=dict(
                 file_path=spikeglx_file_path,
-                dtype="int16"
             ),
             VirmenData=dict(
                 file_path=virmen_file_path

--- a/tank_lab_to_nwb/convert_towers_task/convert_towers.py
+++ b/tank_lab_to_nwb/convert_towers_task/convert_towers.py
@@ -24,8 +24,6 @@ if base_path.is_dir():
         metadata = converter.get_metadata()
 
         # Session specific metadata
-        metadata['NWBFile'].update(session_description="")
-        metadata['Subject'].update(species="Mus musculus")
 
         converter.run_conversion(
             nwbfile_path=str(nwbfile_path.absolute()),

--- a/tank_lab_to_nwb/convert_towers_task/convert_towers.py
+++ b/tank_lab_to_nwb/convert_towers_task/convert_towers.py
@@ -13,8 +13,7 @@ if base_path.is_dir():
     if not nwbfile_path.is_file():
         input_args = dict(
             SpikeGLXRecording=dict(
-                file_path=spikeglx_file_path,
-                sync_with_ttl=True
+                file_path=spikeglx_file_path
             ),
             VirmenData=dict(
                 file_path=virmen_file_path
@@ -28,4 +27,9 @@ if base_path.is_dir():
         metadata['NWBFile'].update(session_description="")
         metadata['Subject'].update(species="Mus musculus")
 
-        converter.run_conversion(nwbfile_path=str(nwbfile_path.absolute()), metadata_dict=metadata, stub_test=True)
+        converter.run_conversion(
+            nwbfile_path=str(nwbfile_path.absolute()),
+            metadata_dict=metadata,
+            stub_test=True,
+            sync_with_ttl=True
+        )

--- a/tank_lab_to_nwb/convert_towers_task/convert_towers.py
+++ b/tank_lab_to_nwb/convert_towers_task/convert_towers.py
@@ -1,59 +1,31 @@
-"""Authors: Cody Baker and Ben Dichter."""
-# TODO: add pathlib
-import os
-
-from joblib import Parallel, delayed
+"""Authors: Alessio Buccino, Cody Baker, Szonja Weigl, and Ben Dichter."""
+from pathlib import Path
 
 from tank_lab_to_nwb import TowersNWBConverter
 
-n_jobs = 1  # number of parallel streams to run
+base_path = Path("D:/Neuropixels/")
+spikeglx_file_path = base_path / "Neuropixels/A256_bank1_2020_09_30/A256_bank1_2020_09_30_g0/" \
+                                 "A256_bank1_2020_09_30_g0_t0.imec0.ap.bin"
+virmen_file_path = base_path / "TowersTask/PoissonBlocksReboot_cohort1_VRTrain6_E75_T_20181105.mat"
+nwbfile_path = base_path / "TowersTask_stub.nwb"
 
-base_path = "D:/Neuropixels/TowersTask"
-# base_path = "/mnt/scrap/cbaker239/Neuropixels/TowersTask"
-
-# Manual list of selected sessions that cause problems with the general functionality
-exlude_sessions = []
-
-virmen_strings = ["PoissonBlocksReboot_cohort1_VRTrain6_E75_T_20181105.mat"]
-nwbfile_paths = []
-for j, session in enumerate(virmen_strings):
-    virmen_strings[j] = os.path.join(base_path, virmen_strings[j])
-    nwbfile_paths.append(os.path.join(base_path, session) + "_local_stub.nwb")
-
-
-def run_tower_conv(session, nwbfile_path):
-    """Conversion function to be run in parallel."""
-    if os.path.exists(base_path):
-        print(f"Processsing {session}...")
-        if not os.path.isfile(nwbfile_path):
-            # construct input_args dict according to input schema
-            input_args = dict(
-                SpikeGLXRecording=dict(
-                    file_path="D:/Neuropixels/Neuropixels/A256_bank1_2020_09_30/"
-                    "A256_bank1_2020_09_30_g0/A256_bank1_2020_09_30_g0_t0.imec0.ap.bin"
-                ),
-                VirmenData=dict(folder_path=session)
+if base_path.is_dir():
+    if not nwbfile_path.is_file():
+        input_args = dict(
+            SpikeGLXRecording=dict(
+                file_path=spikeglx_file_path,
+                sync_with_ttl=True
+            ),
+            VirmenData=dict(
+                file_path=virmen_file_path
             )
+        )
 
-            converter = TowersNWBConverter(**input_args)
-            metadata = converter.get_metadata()
+        converter = TowersNWBConverter(**input_args)
+        metadata = converter.get_metadata()
 
-            # Session specific metadata
-            metadata['NWBFile'].update(session_description="")
-            metadata['Subject'].update(species="Mus musculus")
+        # Session specific metadata
+        metadata['NWBFile'].update(session_description="")
+        metadata['Subject'].update(species="Mus musculus")
 
-            # metadata[yuta_converter.get_recording_type()]['Ecephys']['Device'][0].update({'name': 'implant'})
-
-            # for electrode_group_metadata in \
-            #         metadata[yuta_converter.get_recording_type()]['Ecephys']['ElectrodeGroup']:
-            #     electrode_group_metadata.update({'location': 'unknown'})
-            #     electrode_group_metadata.update({'device_name': 'implant'})
-
-            converter.run_conversion(nwbfile_path=nwbfile_path, metadata_dict=metadata, stub_test=True)
-    else:
-        print(f"The folder ({session}) does not exist!")
-
-
-Parallel(n_jobs=n_jobs)(delayed(run_tower_conv)(session, nwbfile_path)
-                        for session, nwbfile_path in zip(session_strings, nwbfile_paths)
-                        if os.path.split(session)[1] not in exlude_sessions)
+        converter.run_conversion(nwbfile_path=str(nwbfile_path.absolute()), metadata_dict=metadata, stub_test=True)

--- a/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
+++ b/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
@@ -1,5 +1,4 @@
 """Authors: Cody Baker and Ben Dichter."""
-import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -29,24 +28,27 @@ class TowersNWBConverter(NWBConverter):
                 identifier=session_id,
                 session_start_time=session_start.astimezone(),
                 file_create_date=datetime.now().astimezone(),
+                session_description="no description",
                 session_id=session_id,
                 institution="Princeton",
                 lab="Tank"
             ),
-            Subject=dict(),
-            SpikeGLXRecording=None,
-            VirmenData=dict()
+            Subject=dict(
+                species="Mus musculus"
+            ),
         )
 
         if file_path.is_file():
             session_data = convert_mat_file_to_dict(mat_file_name=file_path)
             subject_data = session_data['log']['animal']
-
-            key_map = dict(name='subject_id', importWeight='weight')
-            [metadata['Subject'].update({key_map[k]: str(subject_data[k])}) for k in key_map if k in subject_data]
-
             age_in_iso_format = duration_isoformat(timedelta(weeks=subject_data['importAge']))
-            metadata['Subject'].update(age=age_in_iso_format)
+
+            metadata['Subject'].update(
+                subject_id=subject_data['name'],
+                weight=subject_data['importWeight'],
+                age=age_in_iso_format
+            )
+
         else:
             print(f"Warning: no subject file detected for session {session_id}!")
 

--- a/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
+++ b/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
@@ -25,7 +25,6 @@ class TowersNWBConverter(NWBConverter):
         metadata = super().get_metadata()
         metadata.update(
             NWBFile=dict(
-                identifier=session_id,
                 session_start_time=session_start.astimezone(),
                 file_create_date=datetime.now().astimezone(),
                 session_description="no description",

--- a/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
+++ b/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
@@ -1,6 +1,7 @@
 """Authors: Cody Baker and Ben Dichter."""
 import os
 from datetime import datetime, timedelta
+from pathlib import Path
 
 from dateutil.parser import parse as dateparse
 from isodate import duration_isoformat
@@ -16,16 +17,9 @@ class TowersNWBConverter(NWBConverter):
         VirmenData=VirmenDataInterface,
     )
 
-    def __init__(self, **input_args):
-        self._recording_type = 'SpikeGLXRecording'
-        super().__init__(**input_args)
-
-    def get_recording_type(self):
-        return self._recording_type
-
     def get_metadata(self):
-        session_path = self.data_interface_objects['VirmenData'].input_args['folder_path']
-        subject_path, session_id = os.path.split(session_path)
+        file_path = Path(self.data_interface_objects['VirmenData'].input_args['file_path'])
+        session_id = file_path.stem
 
         session_name = os.path.splitext(session_id)[0]
         date_text = [name for name in session_name.split('_') if name.isdigit()][0]
@@ -40,42 +34,13 @@ class TowersNWBConverter(NWBConverter):
                 institution="Princeton",
                 lab="Tank"
             ),
-            Subject=dict(
-            ),
-            # self.get_recording_type(): {
-            #     'Ecephys': {
-            #         'subset_channels': all_shank_channels,
-            #         'Device': [{
-            #             'description': session_id + '.xml'
-            #         }],
-            #         'ElectrodeGroup': [{
-            #             'name': f'shank{n+1}',
-            #             'description': f'shank{n+1} electrodes'
-            #         } for n, _ in enumerate(shank_channels)],
-            #         'Electrodes': [
-            #             {
-            #                 'name': 'shank_electrode_number',
-            #                 'description': '0-indexed channel within a shank',
-            #                 'data': shank_electrode_number
-            #             },
-            #             {
-            #                 'name': 'group_name',
-            #                 'description': 'the name of the ElectrodeGroup this electrode is a part of',
-            #                 'data': shank_group_name
-            #             }
-            #         ],
-            #         'ElectricalSeries': {
-            #             'name': 'ElectricalSeries',
-            #             'description': 'raw acquisition traces'
-            #         }
-            #     }
-            # },
+            Subject=dict(),
             SpikeGLXRecording=None,
             VirmenData=dict()
         )
 
-        if os.path.isfile(session_path + ".mat"):
-            session_data = convert_mat_file_to_dict(mat_file_name=session_path)
+        if file_path.is_file():
+            session_data = convert_mat_file_to_dict(mat_file_name=file_path)
             subject_data = session_data['log']['animal']
 
             key_map = dict(name='subject_id', importWeight='weight')
@@ -84,6 +49,6 @@ class TowersNWBConverter(NWBConverter):
             age_in_iso_format = duration_isoformat(timedelta(weeks=subject_data['importAge']))
             metadata['Subject'].update(age=age_in_iso_format)
         else:
-            print(f"Warning: no subject file detected for session {session_path}!")
+            print(f"Warning: no subject file detected for session {session_id}!")
 
         return metadata

--- a/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
+++ b/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
@@ -17,13 +17,13 @@ class TowersNWBConverter(NWBConverter):
     )
 
     def get_metadata(self):
-        file_path = Path(self.data_interface_objects['VirmenData'].input_args['file_path'])
-        session_id = file_path.stem
-
+        vermin_file_path = Path(self.data_interface_objects['VirmenData'].input_args['file_path'])
+        session_id = vermin_file_path.stem
         date_text = [id_part for id_part in session_id.split('_') if id_part.isdigit()][0]
         session_start = dateparse(date_text, yearfirst=True)
 
-        metadata = dict(
+        metadata = super().get_metadata()
+        metadata.update(
             NWBFile=dict(
                 identifier=session_id,
                 session_start_time=session_start.astimezone(),
@@ -38,17 +38,15 @@ class TowersNWBConverter(NWBConverter):
             ),
         )
 
-        if file_path.is_file():
-            session_data = convert_mat_file_to_dict(mat_file_name=file_path)
+        if vermin_file_path.is_file():
+            session_data = convert_mat_file_to_dict(mat_file_name=vermin_file_path)
             subject_data = session_data['log']['animal']
             age_in_iso_format = duration_isoformat(timedelta(weeks=subject_data['importAge']))
 
             metadata['Subject'].update(
                 subject_id=subject_data['name'],
-                weight=subject_data['importWeight'],
                 age=age_in_iso_format
             )
-
         else:
             print(f"Warning: no subject file detected for session {session_id}!")
 

--- a/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
+++ b/tank_lab_to_nwb/convert_towers_task/towersnwbconverter.py
@@ -21,8 +21,7 @@ class TowersNWBConverter(NWBConverter):
         file_path = Path(self.data_interface_objects['VirmenData'].input_args['file_path'])
         session_id = file_path.stem
 
-        session_name = os.path.splitext(session_id)[0]
-        date_text = [name for name in session_name.split('_') if name.isdigit()][0]
+        date_text = [id_part for id_part in session_id.split('_') if id_part.isdigit()][0]
         session_start = dateparse(date_text, yearfirst=True)
 
         metadata = dict(

--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -57,7 +57,7 @@ class VirmenDataInterface(BaseDataInterface):
 
         return metadata_schema
 
-    def convert_data(self, nwbfile: NWBFile, metadata_dict: dict, stub_test: bool = False):
+    def convert_data(self, nwbfile: NWBFile, metadata_dict: dict, stub_test: bool = False, **conversion_options):
         """
         Primary conversion function for the custom tank lab behavioral interface.
 

--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -58,7 +58,7 @@ class VirmenDataInterface(BaseDataInterface):
 
         return metadata_schema
 
-    def convert_data(self, nwbfile: NWBFile, metadata_dict: dict, stub_test: bool = False, **conversion_options):
+    def convert_data(self, nwbfile: NWBFile, metadata_dict: dict, stub_test: bool = False):
         """
         Primary conversion function for the custom tank lab behavioral interface.
 

--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -8,6 +8,7 @@ from nwb_conversion_tools.basedatainterface import BaseDataInterface
 from nwb_conversion_tools.utils import get_base_schema, get_schema_from_hdmf_class
 from pynwb import NWBFile, TimeSeries
 from pynwb.behavior import SpatialSeries, Position
+
 from ..utils import check_module, convert_mat_file_to_dict, array_to_dt
 
 
@@ -88,7 +89,7 @@ class VirmenDataInterface(BaseDataInterface):
             epoch_end_nwb = [(epoch_start_dt - session_start_time + epoch_duration).total_seconds()
                              for epoch_start_dt, epoch_duration in zip(epoch_start_dts, epoch_durations)]
             for j, (start, end) in enumerate(zip(epoch_start_nwb, epoch_end_nwb)):
-                nwbfile.add_epoch(start_time=start, stop_time=end, label='Epoch'+str(j+1))
+                nwbfile.add_epoch(start_time=start, stop_time=end, label='Epoch' + str(j + 1))
 
             trial_starts = [trial.start + epoch_start_nwb[0]
                             for epoch in matin['log']['block']


### PR DESCRIPTION
@bendichter A couple things in this PR.

1. Simplified main conversion script, including removing parallel run over multiple sessions (since client is more interested in other part of pipeline), making this a simple test script. Also added reliance on pathlib rather than os.
2. Debugged PR #13 (some of @alejoe91 changes broke the script).
3. Added alternative method for synchronizing with ttl pulses, reliant on [this branch/PR](https://github.com/catalystneuro/nwb-conversion-tools/pull/74). @alejoe91 let me know what you think. We may still need pickle-type interfaces for the processing stuff, but for the simple task of synchronizing the record I think it might be overkill.

@weiglszonja Note that the default nwbfile path location is now one level up.