### PR TITLE
Extend epoch and trial tables

### DIFF
--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -111,6 +111,13 @@ class VirmenDataInterface(BaseDataInterface):
             for k in range(len(trial_starts)):
                 nwbfile.add_trial(start_time=trial_starts[k], stop_time=trial_ends[k])
 
+            trial_excess_travel = [trial.excessTravel for epoch in matin['log']['block']
+                                   for trial in epoch.trial]
+            nwbfile.add_trial_column(name='excess_travel',
+                                     description='total distance traveled during the trial '
+                                                 'normalized to the length of the maze',
+                                     data=trial_excess_travel)
+
             # Processed position, velocity
             pos_obj = Position(name="Position")
 

--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -113,11 +113,25 @@ class VirmenDataInterface(BaseDataInterface):
 
             trial_excess_travel = [trial.excessTravel for epoch in matin['log']['block']
                                    for trial in epoch.trial]
+            trial_cue_onsets = [trial.cueOnset for epoch in matin['log']['block'] for trial in
+                                epoch.trial]
+            trial_cue_offsets = [trial.cueOffset for epoch in matin['log']['block'] for trial in
+                                 epoch.trial]
+            trial_cue_positions = [trial.cuePos for epoch in matin['log']['block'] for trial in
+                                   epoch.trial]
             nwbfile.add_trial_column(name='excess_travel',
                                      description='total distance traveled during the trial '
                                                  'normalized to the length of the maze',
                                      data=trial_excess_travel)
-
+            nwbfile.add_trial_column(name='cue_onset',
+                                     description='iteration number of ViRMEn when cues are switched on',
+                                     data=trial_cue_onsets)
+            nwbfile.add_trial_column(name='cue_offset',
+                                     description='iteration number of ViRMEn when cues are switched off',
+                                     data=trial_cue_offsets)
+            nwbfile.add_trial_column(name='cue_position',
+                                     description='position of the cues in cm',
+                                     data=trial_cue_positions)
             # Processed position, velocity
             pos_obj = Position(name="Position")
 

--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -90,6 +90,19 @@ class VirmenDataInterface(BaseDataInterface):
             for j, (start, end) in enumerate(zip(epoch_start_nwb, epoch_end_nwb)):
                 nwbfile.add_epoch(start_time=start, stop_time=end, label='Epoch'+str(j+1))
 
+            epoch_maze_ids = [epoch.mazeID for epoch in matin['log']['block']]
+            epoch_reward_mil = [epoch.rewardMiL for epoch in matin['log']['block']]
+            epoch_stimulus_config = [epoch.stimulusConfig for epoch in matin['log']['block']]
+            nwbfile.add_epoch_column(name='maze_id',
+                                     description='identifier of the ViRMEn maze',
+                                     data=epoch_maze_ids)
+            nwbfile.add_epoch_column(name='reward_ml',
+                                     description='reward in ml',
+                                     data=epoch_reward_mil)
+            nwbfile.add_epoch_column(name='stimulus_config',
+                                     description='stimulus configuration number',
+                                     data=epoch_stimulus_config)
+
             trial_starts = [trial.start + epoch_start_nwb[0]
                             for epoch in matin['log']['block']
                             for trial in epoch.trial]


### PR DESCRIPTION
- `mazeID`, `rewardMiL` and `stimulusConfig` are added to epoch table
- `excessTravel` is added to trial table
- `cue_orientation` refers to which side the cue was presented for each trial (left, right or both) 
