### PR TITLE
Add conversion for Position values

### DIFF
--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -150,6 +150,7 @@ class VirmenDataInterface(BaseDataInterface):
                     name="SpatialSeries",
                     data=H5DataIO(pos_data, compression="gzip"),
                     reference_frame="unknown",
+                    conversion=0.01,
                     resolution=np.nan,
                     timestamps=H5DataIO(timestamps, compression="gzip")
                 )


### PR DESCRIPTION
Small fix to convert position values [cm] to match SpatialSeries default unit in meters. 
