### PR TITLE
Fix converting file with single epoch

### DIFF
--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -86,8 +86,7 @@ class VirmenDataInterface(BaseDataInterface):
             if isinstance(matin['log']['block'], dict):
                 epochs = [matin['log']['block']]
             else:
-                epochs = [mat_obj_to_dict(epoch) for epoch in matin['log']['block'] if
-                          isinstance(epoch, matlab.mio5_params.mat_struct)]
+                epochs = matin['log']['block']
 
             epoch_start_dts = [array_to_dt(epoch['start']) for epoch in epochs]
             epoch_durations = [timedelta(seconds=epoch['duration']) for epoch in epochs]
@@ -112,8 +111,7 @@ class VirmenDataInterface(BaseDataInterface):
                                      description='stimulus configuration number',
                                      data=epoch_stimulus_config)
 
-            trials = [mat_obj_to_dict(trial) for epoch in epochs for trial in epoch['trial']
-                      if isinstance(trial, matlab.mio5_params.mat_struct)]
+            trials = [trial for epoch in epochs for trial in epoch['trial']]
             trial_starts = [trial['start'] + epoch_start_nwb[0] for trial in trials]
             trial_durations = [trial['duration'] for trial in trials]
             trial_ends = [start_time + duration for start_time, duration in

--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -168,32 +168,32 @@ class VirmenDataInterface(BaseDataInterface):
 
             nwbfile.add_trial_column(name='left_cue_onset',
                                      description='onset times of left cues',
-                                     index=left_cue_data_indices,
+                                     index=left_cue_onset_indices,
                                      data=left_cue_onset_data)
 
             nwbfile.add_trial_column(name='right_cue_onset',
                                      description='onset times of right cues',
-                                     index=right_cue_data_indices,
+                                     index=right_cue_onset_indices,
                                      data=right_cue_onset_data)
 
             nwbfile.add_trial_column(name='left_cue_offset',
                                      description='offset times of left cues',
-                                     index=left_cue_data_indices,
+                                     index=left_cue_offset_indices,
                                      data=left_cue_offset_data)
 
             nwbfile.add_trial_column(name='right_cue_offset',
                                      description='offset times of right cues',
-                                     index=right_cue_data_indices,
+                                     index=right_cue_offset_indices,
                                      data=right_cue_offset_data)
 
             nwbfile.add_trial_column(name='left_cue_position',
                                      description='position of left cues',
-                                     index=left_cue_data_indices,
+                                     index=left_cue_position_indices,
                                      data=left_cue_position_data)
 
             nwbfile.add_trial_column(name='right_cue_position',
                                      description='position of right cues',
-                                     index=right_cue_data_indices,
+                                     index=right_cue_position_indices,
                                      data=right_cue_position_data)
 
             # Processed position, velocity, viewAngle

--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -3,14 +3,12 @@ from datetime import timedelta
 from pathlib import Path
 
 import numpy as np
-from scipy.io import matlab
 from hdmf.backends.hdf5.h5_utils import H5DataIO
 from nwb_conversion_tools.basedatainterface import BaseDataInterface
 from nwb_conversion_tools.utils import get_base_schema, get_schema_from_hdmf_class
 from pynwb import NWBFile, TimeSeries
 from pynwb.behavior import SpatialSeries, Position, CompassDirection
-from ..utils import check_module, convert_mat_file_to_dict, array_to_dt, create_indexed_array, \
-    mat_obj_to_dict
+from ..utils import check_module, convert_mat_file_to_dict, array_to_dt, create_indexed_array
 
 
 class VirmenDataInterface(BaseDataInterface):

--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -87,40 +87,32 @@ class VirmenDataInterface(BaseDataInterface):
                                      data=trial_excess_travel)
 
             # Processed cue timing and position
-            left_cue_onsets = [trial['time'][trial['cueOnset'][0] - 1]
-                               if np.any(trial['cueOnset'][0]) else np.nan for trial in trials]
-            trial_left_cue_onsets = [trial_start + cue_onset for trial_start, cue_onset
-                                     in zip(trial_starts, left_cue_onsets)]
-            left_cue_onset_data, left_cue_onset_indices = create_indexed_array(
-                trial_left_cue_onsets)
+            left_cue_onsets = [
+                trial['start'] + epoch_start_nwb[0] + trial['time'][trial['cueOnset'][0] - 1]
+                if np.any(trial['cueOnset'][0]) else [] for trial in trials]
+            left_cue_onset_data, left_cue_onset_indices = create_indexed_array(left_cue_onsets)
 
-            right_cue_onsets = [trial['time'][trial['cueOnset'][1] - 1]
-                                if np.any(trial['cueOnset'][1]) else np.nan for trial in trials]
-            trial_right_cue_onsets = [trial_start + cue_onset for trial_start, cue_onset
-                                      in zip(trial_starts, right_cue_onsets)]
-            right_cue_onset_data, right_cue_onset_indices = create_indexed_array(
-                trial_right_cue_onsets)
+            right_cue_onsets = [
+                trial['start'] + epoch_start_nwb[0] + trial['time'][trial['cueOnset'][1] - 1]
+                if np.any(trial['cueOnset'][1]) else [] for trial in trials]
+            right_cue_onset_data, right_cue_onset_indices = create_indexed_array(right_cue_onsets)
 
-            left_cue_offsets = [trial['time'][trial['cueOffset'][0] - 1]
-                                if np.any(trial['cueOffset'][0]) else np.nan for trial in trials]
-            trial_left_cue_offsets = [trial_start + cue_offset for trial_start, cue_offset
-                                      in zip(trial_starts, left_cue_offsets)]
-            left_cue_offset_data, left_cue_offset_indices = create_indexed_array(
-                trial_left_cue_offsets)
+            left_cue_offsets = [
+                trial['start'] + epoch_start_nwb[0] + trial['time'][trial['cueOffset'][0] - 1]
+                if np.any(trial['cueOffset'][0]) else [] for trial in trials]
+            left_cue_offset_data, left_cue_offset_indices = create_indexed_array(left_cue_offsets)
 
-            right_cue_offsets = [trial['time'][trial['cueOffset'][1] - 1]
-                                 if np.any(trial['cueOffset'][1]) else np.nan for trial in trials]
-            trial_right_cue_offsets = [trial_start + cue_offset for trial_start, cue_offset
-                                       in zip(trial_starts, right_cue_offsets)]
-            right_cue_offset_data, right_cue_offset_indices = create_indexed_array(
-                trial_right_cue_offsets)
+            right_cue_offsets = [
+                trial['start'] + epoch_start_nwb[0] + trial['time'][trial['cueOffset'][1] - 1]
+                if np.any(trial['cueOffset'][1]) else [] for trial in trials]
+            right_cue_offset_data, right_cue_offset_indices = create_indexed_array(right_cue_offsets)
 
-            left_cue_positions = [trial['cuePos'][0] if np.any(trial['cuePos'][0]) else np.nan
+            left_cue_positions = [trial['cuePos'][0] if np.any(trial['cuePos'][0]) else []
                                   for trial in trials]
             left_cue_position_data, left_cue_position_indices = create_indexed_array(
                 left_cue_positions)
 
-            right_cue_positions = [trial['cuePos'][1] if np.any(trial['cuePos'][1]) else np.nan
+            right_cue_positions = [trial['cuePos'][1] if np.any(trial['cuePos'][1]) else []
                                    for trial in trials]
             right_cue_position_data, right_cue_position_indices = create_indexed_array(
                 right_cue_positions)

--- a/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
+++ b/tank_lab_to_nwb/convert_towers_task/virmenbehaviordatainterface.py
@@ -157,7 +157,7 @@ class VirmenDataInterface(BaseDataInterface):
             view_angle_data = []
             for trial in trials:
                 trial_total_time = trial['start'] + epoch_start_nwb[0] + trial['time']
-                timestamps.extend(trial_total_time)
+                timestamps.extend(trial_total_time.astype(np.float64, casting='same_kind'))
 
                 padding = np.full((trial['time'].shape[0] - trial['position'].shape[0], 2), np.nan)
                 trial_position = trial['position'][:, :-1]

--- a/tank_lab_to_nwb/utils.py
+++ b/tank_lab_to_nwb/utils.py
@@ -60,7 +60,30 @@ def mat_obj_to_dict(mat_struct):
         dict_from_struct[field_name] = mat_struct.__dict__[field_name]
         if isinstance(dict_from_struct[field_name], matlab.mio5_params.mat_struct):
             dict_from_struct[field_name] = mat_obj_to_dict(dict_from_struct[field_name])
+        elif isinstance(dict_from_struct[field_name], np.ndarray):
+            try:
+                dict_from_struct[field_name] = mat_obj_to_array(dict_from_struct[field_name])
+            except TypeError:
+                continue
     return dict_from_struct
+
+
+def mat_obj_to_array(mat_struct_array):
+    """Construct array from matlab cell arrays.
+    Recursively converts array elements if they contain mat objects."""
+    if has_struct(mat_struct_array):
+        array_from_cell = [mat_obj_to_dict(mat_struct) for mat_struct in mat_struct_array]
+        array_from_cell = np.array(array_from_cell)
+    else:
+        array_from_cell = mat_struct_array
+
+    return array_from_cell
+
+
+def has_struct(mat_struct_array):
+    """Determines if a matlab cell array contains any mat objects."""
+    return any(
+        isinstance(mat_struct, matlab.mio5_params.mat_struct) for mat_struct in mat_struct_array)
 
 
 def convert_mat_file_to_dict(mat_file_name):

--- a/tank_lab_to_nwb/utils.py
+++ b/tank_lab_to_nwb/utils.py
@@ -119,6 +119,6 @@ def create_indexed_array(ndarray):
         else:
             flat_array.append(array)
             array_indices.append(1)
-    array_indices = np.cumsum(array_indices)
+    array_indices = np.cumsum(array_indices, dtype=np.uint64)
 
     return flat_array, array_indices


### PR DESCRIPTION
The aim of this PR is to adapt `virmenbehaviordatainterface.py` to be able to convert sessions with single or multiple epochs.
The current implementation assumes that sessions have multiple epochs, however we also received a sample file (e.g. `PoissonBlocksReboot4_cohort4_NPX2_testuser_T40_T_20201030.mat`) with only 1 epoch. 

In order to unify the processing of such sessions:
- converting sessions with single multiple epochs to list of dict(s)
- adapt how we extract data from epochs and trials

This PR also modifies how cues are added to the Trial table; each column should have their own index, because it can happen that unequal number of cues are present within the same side (until now I assumed it should be equal for each side).