### PR TITLE
polished nwb conversion scripts, removed from main pipeline, and included ecephys metadata

### DIFF
--- a/notebooks/spikeinterface_pipeline.ipynb
+++ b/notebooks/spikeinterface_pipeline.ipynb
@@ -22,8 +22,6 @@
     "from nwb_conversion_tools.conversion_tools import save_si_object\n",
     "from tank_lab_to_nwb import TowersProcessedNWBConverter\n",
     "\n",
-    "from isodate import duration_isoformat\n",
-    "from datetime import timedelta\n",
     "from pathlib import Path\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
@@ -598,56 +596,6 @@
    "outputs": [],
    "source": [
     "multi_rec = se.MultiRecordingTimeExtractor?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Convert to NWB"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "recording_pickle_file = spikeinterface_folder / 'raw.pkl'\n",
-    "#sorting_pickle_file = spikeinterface_folder / 'sorting_ensemble.pkl'\n",
-    "sorting_pickle_file = spikeinterface_folder / 'sorter1.pkl'\n",
-    "\n",
-    "base_path = Path(\"D:/Neuropixels/\")\n",
-    "virmen_file_path = base_path / \"TowersTask/PoissonBlocksReboot_cohort1_VRTrain6_E75_T_20181105.mat\"\n",
-    "nwbfile_path = base_path / \"TankProcessing_stub.nwb\"\n",
-    "session_description = \"Enter session description here.\"\n",
-    "\n",
-    "# Enter Subject information here\n",
-    "# Comment out or remove any fields you do not want to include\n",
-    "subject_info = dict(\n",
-    "    description=\"Enter optional subject description here\",\n",
-    "    weight=\"Enter subject weight here\",\n",
-    "    age=duration_isoformat(timedelta(days=0)),  # Enter the age of the subject in days\n",
-    "    species=\"Mus musculus\",\n",
-    "    genotype=\"Enter subject genotype here\",\n",
-    "    sex=\"Enter subject sex here\"\n",
-    ")\n",
-    "\n",
-    "source_data = dict(\n",
-    "    SIRecording=dict(pkl_file=str(recording_pickle_file.absolute())),\n",
-    "    SISorting=dict(pkl_file=str(sorting_pickle_file.absolute())),\n",
-    "    VirmenData=dict(file_path=str(virmen_file_path.absolute()))\n",
-    ")\n",
-    "conversion_options = dict(\n",
-    "    SIRecording=dict(stub_test=True),\n",
-    "    SISorting=dict(stub_test=True)\n",
-    ")\n",
-    "\n",
-    "converter = TowersProcessedNWBConverter(**source_data)\n",
-    "metadata = converter.get_metadata()\n",
-    "metadata['NWBFile'].update(session_description=session_description)\n",
-    "metadata['Subject'].update(subject_info)\n",
-    "converter.run_conversion(nwbfile_path=str(nwbfile_path.absolute()), metadata=metadata, conversion_options=conversion_options)"
    ]
   }
  ],

--- a/notebooks/spikeinterface_pipeline_testing.ipynb
+++ b/notebooks/spikeinterface_pipeline_testing.ipynb
@@ -551,65 +551,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#st.postprocessing.export_to_phy"
+    "st.postprocessing.export_to_phy"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Convert to NWB"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "recording_pickle_file = spikeinterface_folder / 'raw.pkl'\n",
-    "#sorting_pickle_file = spikeinterface_folder / 'sorting_ensemble.pkl'\n",
-    "sorting_pickle_file = spikeinterface_folder / 'sorter1.pkl'\n",
-    "\n",
-    "base_path = Path(\"D:/Neuropixels/\")\n",
-    "virmen_file_path = base_path / \"TowersTask/PoissonBlocksReboot_cohort1_VRTrain6_E75_T_20181105.mat\"\n",
-    "nwbfile_path = base_path / \"TankProcessing_stub.nwb\"\n",
-    "session_description = \"Enter session description here.\"\n",
-    "\n",
-    "# Enter Subject information here\n",
-    "# Comment out or remove any fields you do not want to include\n",
-    "subject_info = dict(\n",
-    "    description=\"Enter optional subject description here\",\n",
-    "    weight=\"Enter subject weight here\",\n",
-    "    age=duration_isoformat(timedelta(days=0)),  # Enter the age of the subject in days\n",
-    "    species=\"Mus musculus\",\n",
-    "    genotype=\"Enter subject genotype here\",\n",
-    "    sex=\"Enter subject sex here\"\n",
-    ")\n",
-    "\n",
-    "source_data = dict(\n",
-    "    SIRecording=dict(pkl_file=str(recording_pickle_file.absolute())),\n",
-    "    SISorting=dict(pkl_file=str(sorting_pickle_file.absolute())),\n",
-    "    VirmenData=dict(file_path=str(virmen_file_path.absolute()))\n",
-    ")\n",
-    "conversion_options = dict(\n",
-    "    SIRecording=dict(stub_test=True),\n",
-    "    SISorting=dict(stub_test=True)\n",
-    ")\n",
-    "\n",
-    "converter = TowersProcessedNWBConverter(**source_data)\n",
-    "metadata = converter.get_metadata()\n",
-    "metadata['NWBFile'].update(session_description=session_description)\n",
-    "metadata['Subject'].update(subject_info)\n",
-    "converter.run_conversion(nwbfile_path=str(nwbfile_path.absolute()), metadata=metadata, conversion_options=conversion_options)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tank_lab_to_nwb/convert_towers_task/convert_towers_processed.py
+++ b/tank_lab_to_nwb/convert_towers_task/convert_towers_processed.py
@@ -1,0 +1,66 @@
+"""Authors: Alessio Buccino, Cody Baker, Szonja Weigl, and Ben Dichter."""
+from pathlib import Path
+from isodate import duration_isoformat
+from datetime import timedelta
+
+import nwb_conversion_tools as ct
+import spikeextractors as se
+
+from tank_lab_to_nwb import TowersProcessedNWBConverter
+
+# Point to the base folder path for both recording data and Virmen
+base_path = Path("D:/Neuropixels/")
+
+# Name the NWBFile and point to the desired save path
+nwbfile_path = base_path / "TankProcessing_stub.nwb"
+
+# Point to the various files for the conversion
+recording_folder = base_path / "Neuropixels" / "A256_bank1_2020_09_30" / "A256_bank1_2020_09_30_g0"
+spikeinterface_folder = recording_folder / "spikeinterface"
+raw_data_file = recording_folder / "A256_bank1_2020_09_30_g0_t0.imec0.ap.bin"
+recording_pickle_file = spikeinterface_folder / "raw.pkl"
+sorting_pickle_file = spikeinterface_folder / "sorter1.pkl"
+virmen_file_path = base_path / "TowersTask" / "PoissonBlocksReboot_cohort1_VRTrain6_E75_T_20181105.mat"
+
+# Enter Session and Subject information here
+# Comment out or remove any fields you do not want to include
+session_description = "Enter session description here."
+
+subject_info = dict(
+    description="Enter optional subject description here",
+    weight="Enter subject weight here",
+    age=duration_isoformat(timedelta(days=0)),  # Enter the age of the subject in days
+    species="Mus musculus",
+    genotype="Enter subject genotype here",
+    sex="Enter subject sex here"
+)
+
+
+# Set some conversion options
+# Recommend setting stub_test to True for first conversion to allow fast testing/validation
+conversion_options = dict(
+    SIRecording=dict(stub_test=True),
+    SISorting=dict(stub_test=True)
+)
+
+# Run the conversion
+source_data = dict(
+    SIRecording=dict(pkl_file=str(recording_pickle_file.absolute())),
+    SISorting=dict(pkl_file=str(sorting_pickle_file.absolute())),
+    VirmenData=dict(file_path=str(virmen_file_path.absolute()))
+)
+converter = TowersProcessedNWBConverter(source_data)
+metadata = converter.get_metadata()
+metadata['NWBFile'].update(session_description=session_description)
+metadata['Subject'].update(subject_info)
+metadata.update(
+    ct.SpikeGLXRecordingInterface.get_ecephys_metadata(
+        spikeglx_meta=se.extractors.spikeglxrecordingextractor.readSGLX.readMeta(raw_data_file),
+        channel_ids=converter.data_interface_objects['SIRecording'].recording_extractor.get_channel_ids()
+    )
+)
+converter.run_conversion(
+    nwbfile_path=str(nwbfile_path.absolute()),
+    metadata=metadata,
+    conversion_options=conversion_options
+)

--- a/tank_lab_to_nwb/convert_towers_task/convert_towers_raw.py
+++ b/tank_lab_to_nwb/convert_towers_task/convert_towers_raw.py
@@ -1,7 +1,7 @@
 """Authors: Alessio Buccino, Cody Baker, Szonja Weigl, and Ben Dichter."""
 from pathlib import Path
 
-from tank_lab_to_nwb import TowersNWBConverter
+from tank_lab_to_nwb import TowersRawNWBConverter
 
 base_path = Path("D:/Neuropixels/")
 spikeglx_file_path = base_path / "Neuropixels/A256_bank1_2020_09_30/A256_bank1_2020_09_30_g0/" \
@@ -18,7 +18,7 @@ if base_path.is_dir():
         SpikeGLXRecording=dict(stub_test=True)
     )
 
-    converter = TowersNWBConverter(**source_data)
+    converter = TowersRawNWBConverter(**source_data)
     metadata = converter.get_metadata()
     metadata['NWBFile'].update(session_description="Enter session description here.")
     converter.run_conversion(


### PR DESCRIPTION
@bendichter Relies on the [spikeglx interface metadata generalization PR](https://github.com/catalystneuro/nwb-conversion-tools/pull/105).

There are now two scripts for two example conversions, one 'raw' (mostly for testing) and one 'processed' (from the pipeline). The processed one is the one really intended for use by the client, and has been polished accordingly; we can discuss and/or decide to remove to the 'raw' one altogether.

As per discussion with Alessio, the actual nwb conversion is now intended to be done using that script outside the notebook processing pipeline since the client may wish to run multiple pipelines prior to final conversion, so this gives them that freedom. The final actions of the pipeline are essentially to save the SpikeInterface objects to the `spikeinterface` folder used by the processing pipeline.